### PR TITLE
[Feat/#21] 홈 토글 컴포넌트 추가

### DIFF
--- a/src/shared/components/HomeToggle/HomeToggle.css.ts
+++ b/src/shared/components/HomeToggle/HomeToggle.css.ts
@@ -5,7 +5,6 @@ import { recipe } from '@vanilla-extract/recipes';
 export const toggleWrapper = style({
   width: 130,
   height: 28,
-  backgroundColor: 'black',
 })
 
 export const toggleContainer = style({

--- a/src/shared/components/HomeToggle/HomeToggle.css.ts
+++ b/src/shared/components/HomeToggle/HomeToggle.css.ts
@@ -21,6 +21,12 @@ export const toggleContainer = style({
 })
 
 export const toggleText = recipe({
+  base: {
+    backgroundColor: 'transparent',
+    border: 'none',
+    padding: 0,
+    cursor: 'pointer',
+  },
   variants: {
     active: {
       true: [

--- a/src/shared/components/HomeToggle/HomeToggle.css.ts
+++ b/src/shared/components/HomeToggle/HomeToggle.css.ts
@@ -1,6 +1,6 @@
-import {style} from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css'
 import { color, font } from '@/app/styles.css'
-import { recipe } from '@vanilla-extract/recipes';
+import { recipe } from '@vanilla-extract/recipes'
 
 export const toggleWrapper = style({
   width: 130,
@@ -23,27 +23,30 @@ export const toggleContainer = style({
 export const toggleText = recipe({
   variants: {
     active: {
-      true: [font.title_sb_14, {color: 'white', zIndex: 2, cursor: 'default'}],
-      false: [font.title_m_14, { color: color.gray.gray6}],
+      true: [
+        font.title_sb_14,
+        { color: 'white', zIndex: 2, cursor: 'default' },
+      ],
+      false: [font.title_m_14, { color: color.gray.gray6 }],
     },
   },
-});
+})
 
-export const toggleButton = style({
-  backgroundColor: color.brand.primary,
-  width: 66,
-  height: 28,
-  borderRadius: 999,
-  position: 'absolute',
-  top: 0,
-  transition: 'left 0.3s ease',
-  cursor: 'default',
-});
-
-export const toggleButtonOn = style({
-  left: 64,
-});
-
-export const toggleButtonOff = style({
-  left: 0,
-});
+export const toggleButton = recipe({
+  base: {
+    backgroundColor: color.brand.primary,
+    width: 66,
+    height: 28,
+    borderRadius: 999,
+    position: 'absolute',
+    top: 0,
+    transition: 'left 0.3s ease',
+    cursor: 'default',
+  },
+  variants: {
+    active: {
+      true: { left: 0 },
+      false: { left: 64 },
+    },
+  },
+})

--- a/src/shared/components/HomeToggle/HomeToggle.css.ts
+++ b/src/shared/components/HomeToggle/HomeToggle.css.ts
@@ -1,0 +1,50 @@
+import {style} from '@vanilla-extract/css';
+import { color, font } from '@/app/styles.css'
+import { recipe } from '@vanilla-extract/recipes';
+
+export const toggleWrapper = style({
+  width: 130,
+  height: 28,
+  backgroundColor: 'black',
+})
+
+export const toggleContainer = style({
+  backgroundColor: 'white',
+  position: 'relative',
+  height: 28,
+  borderRadius: 999,
+  cursor: 'pointer',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '27px',
+  transition: '0.3s ease',
+})
+
+export const toggleText = recipe({
+  variants: {
+    active: {
+      true: [font.title_sb_14, {color: 'white', zIndex: 2, cursor: 'default'}],
+      false: [font.title_m_14, { color: color.gray.gray6}],
+    },
+  },
+});
+
+export const toggleButton = style({
+  backgroundColor: color.brand.primary,
+  width: 66,
+  height: 28,
+  borderRadius: 999,
+  position: 'absolute',
+  top: 0,
+  transition: 'left 0.3s ease',
+  cursor: 'default',
+});
+
+export const toggleButtonOn = style({
+  left: 64,
+});
+
+export const toggleButtonOff = style({
+  left: 0,
+});

--- a/src/shared/components/HomeToggle/HomeToggle.tsx
+++ b/src/shared/components/HomeToggle/HomeToggle.tsx
@@ -1,46 +1,51 @@
-'use client';
-import React, { useState } from 'react';
-import * as style from "./HomeToggle.css";
-import clsx from 'clsx';
+'use client'
+import { useState, MouseEvent } from 'react'
+import * as style from './HomeToggle.css'
 
 const HomeToggle = () => {
-
   const TOGGLE_OPTIONS = {
     WATCHA_HOME: '왓챠홈',
     MAGAZINE: '매거진',
-  };
+  }
 
-  const [selected, setSelected] = useState<string>(TOGGLE_OPTIONS.WATCHA_HOME);
+  const [selected, setSelected] = useState<string>(TOGGLE_OPTIONS.WATCHA_HOME)
 
   const handleToggle = (value: string) => {
-    setSelected(value);
-  };
+    setSelected(value)
+  }
 
-  const handleStopClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
+  const handleStopClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation()
   }
 
   return (
     <div className={style.toggleWrapper}>
       <div className={style.toggleContainer}>
-          <p 
-            className={style.toggleText({ active: selected === TOGGLE_OPTIONS.WATCHA_HOME })}
-            onClick={() => handleToggle(TOGGLE_OPTIONS.WATCHA_HOME)}
-            >왓챠홈
-          </p>
-          <p 
-            className={style.toggleText({ active: selected === TOGGLE_OPTIONS.MAGAZINE})}
-            onClick={() => handleToggle(TOGGLE_OPTIONS.MAGAZINE)}
-          >매거진
-          </p>
-          <div className={clsx(
-            style.toggleButton,
-            selected === TOGGLE_OPTIONS.MAGAZINE ? style.toggleButtonOn : style.toggleButtonOff)}
-            onClick={handleStopClick}
-          ></div>
-        </div>
+        <p
+          className={style.toggleText({
+            active: selected === TOGGLE_OPTIONS.WATCHA_HOME,
+          })}
+          onClick={() => handleToggle(TOGGLE_OPTIONS.WATCHA_HOME)}
+        >
+          {TOGGLE_OPTIONS.WATCHA_HOME}
+        </p>
+        <p
+          className={style.toggleText({
+            active: selected === TOGGLE_OPTIONS.MAGAZINE,
+          })}
+          onClick={() => handleToggle(TOGGLE_OPTIONS.MAGAZINE)}
+        >
+          {TOGGLE_OPTIONS.MAGAZINE}
+        </p>
+        <div
+          className={style.toggleButton({
+            active: selected === TOGGLE_OPTIONS.WATCHA_HOME,
+          })}
+          onClick={handleStopClick}
+        />
       </div>
-  );
-};
+    </div>
+  )
+}
 
-export default HomeToggle;
+export default HomeToggle

--- a/src/shared/components/HomeToggle/HomeToggle.tsx
+++ b/src/shared/components/HomeToggle/HomeToggle.tsx
@@ -21,22 +21,22 @@ const HomeToggle = () => {
   return (
     <div className={style.toggleWrapper}>
       <div className={style.toggleContainer}>
-        <p
+        <button
           className={style.toggleText({
             active: selected === TOGGLE_OPTIONS.WATCHA_HOME,
           })}
           onClick={() => handleToggle(TOGGLE_OPTIONS.WATCHA_HOME)}
         >
           {TOGGLE_OPTIONS.WATCHA_HOME}
-        </p>
-        <p
+        </button>
+        <button
           className={style.toggleText({
             active: selected === TOGGLE_OPTIONS.MAGAZINE,
           })}
           onClick={() => handleToggle(TOGGLE_OPTIONS.MAGAZINE)}
         >
           {TOGGLE_OPTIONS.MAGAZINE}
-        </p>
+        </button>
         <div
           className={style.toggleButton({
             active: selected === TOGGLE_OPTIONS.WATCHA_HOME,

--- a/src/shared/components/HomeToggle/HomeToggle.tsx
+++ b/src/shared/components/HomeToggle/HomeToggle.tsx
@@ -1,0 +1,46 @@
+'use client';
+import React, { useState } from 'react';
+import * as style from "./HomeToggle.css";
+import clsx from 'clsx';
+
+const HomeToggle = () => {
+
+  const TOGGLE_OPTIONS = {
+    WATCHA_HOME: '왓챠홈',
+    MAGAZINE: '매거진',
+  };
+
+  const [selected, setSelected] = useState<string>(TOGGLE_OPTIONS.WATCHA_HOME);
+
+  const handleToggle = (value: string) => {
+    setSelected(value);
+  };
+
+  const handleStopClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  }
+
+  return (
+    <div className={style.toggleWrapper}>
+      <div className={style.toggleContainer}>
+          <p 
+            className={style.toggleText({ active: selected === TOGGLE_OPTIONS.WATCHA_HOME })}
+            onClick={() => handleToggle(TOGGLE_OPTIONS.WATCHA_HOME)}
+            >왓챠홈
+          </p>
+          <p 
+            className={style.toggleText({ active: selected === TOGGLE_OPTIONS.MAGAZINE})}
+            onClick={() => handleToggle(TOGGLE_OPTIONS.MAGAZINE)}
+          >매거진
+          </p>
+          <div className={clsx(
+            style.toggleButton,
+            selected === TOGGLE_OPTIONS.MAGAZINE ? style.toggleButtonOn : style.toggleButtonOff)}
+            onClick={handleStopClick}
+          ></div>
+        </div>
+      </div>
+  );
+};
+
+export default HomeToggle;


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #21 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 매거진과 왓챠홈을 전환할 토글 컴포넌트를 추가했습니다.

1. ## 작업 내용

- 애니메이션 적용시켜 selected라는 변수에 왓챠홈, 매거진 값을 담아뒀습니다!

## 📢 To Reviewers

- 왓챠홈이랑 매거진 문자열을 따로 **TOGGLE_OPTIONS**으로 빼서 관리해줬는데 이걸 다른 파일에다가 분리시켜야할까요?? 어디다가 분리시켜야할지 몰라서 일단 파일 내에다가 올려두었습니다..
- selected 변수에다가 왓챠홈, 매거진 값을 담아뒀는데 방식이 맞는지 확인해주시면 감사하겠습니다 !

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
왓챠홈 선택 후
<img width="173" alt="스크린샷 2025-05-14 오전 1 08 28" src="https://github.com/user-attachments/assets/d4c1a80f-d435-439c-9deb-ea3cee9158eb" />

매거진 선택 후
<img width="162" alt="스크린샷 2025-05-14 오전 1 08 05" src="https://github.com/user-attachments/assets/22896850-4add-4f5c-a7a9-b74970dbb04f" />

영상

https://github.com/user-attachments/assets/79c85327-3313-410b-9120-ad502727b28c


## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
<img width="345" alt="스크린샷 2025-05-14 오전 3 09 17" src="https://github.com/user-attachments/assets/3e33ba0f-228d-4532-91fe-4e3283f6060d" />

