### PR TITLE
[Feat/#39] 컨텐츠 조회 페이지 레이아웃 설정 및 고정 레이아웃 정의

### DIFF
--- a/src/app/content/[id]/components/HeaderSection/HeaderSection.css.ts
+++ b/src/app/content/[id]/components/HeaderSection/HeaderSection.css.ts
@@ -1,0 +1,38 @@
+import { color, font } from '@/app/styles.css'
+import { style } from '@vanilla-extract/css'
+
+export const HeaderSectionContainer = style({
+  gap: 12,
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+export const HeaderSectionHeaderContainer = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+})
+
+export const HeaderSectionTitle = style([
+  font.headline_b_24,
+  {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+  },
+])
+
+export const HeaderSectionCount = style([
+  font.body_r_14,
+  {
+    color: color.brand.primary,
+  },
+])
+
+export const HeaderSectionMoreButton = style([
+  font.body_r_14,
+  {
+    all: 'unset',
+    color: color.brand.primary,
+  },
+])

--- a/src/app/content/[id]/components/HeaderSection/HeaderSection.css.ts
+++ b/src/app/content/[id]/components/HeaderSection/HeaderSection.css.ts
@@ -1,10 +1,15 @@
 import { color, font } from '@/app/styles.css'
 import { style } from '@vanilla-extract/css'
+import { recipe } from '@vanilla-extract/recipes'
 
-export const HeaderSectionContainer = style({
-  gap: 12,
-  display: 'flex',
-  flexDirection: 'column',
+export const HeaderSectionContainer = recipe({
+  base: { display: 'flex', flexDirection: 'column' },
+  variants: {
+    gap: {
+      sm: { gap: '12px' },
+      lg: { gap: '20px' },
+    },
+  },
 })
 
 export const HeaderSectionHeaderContainer = style({

--- a/src/app/content/[id]/components/HeaderSection/HeaderSection.tsx
+++ b/src/app/content/[id]/components/HeaderSection/HeaderSection.tsx
@@ -20,7 +20,7 @@ const HeaderSection = ({
       <div className={styles.HeaderSectionHeaderContainer}>
         <h3 className={styles.HeaderSectionTitle}>
           {title}
-          <span className={styles.HeaderSectionCount}>{count}</span>
+          {!!count && <span className={styles.HeaderSectionCount}>{count}</span>}
         </h3>
         {moreButton && (
           <button type="button" className={styles.HeaderSectionMoreButton}>

--- a/src/app/content/[id]/components/HeaderSection/HeaderSection.tsx
+++ b/src/app/content/[id]/components/HeaderSection/HeaderSection.tsx
@@ -1,0 +1,34 @@
+import * as styles from './HeaderSection.css'
+
+interface HeaderSectionProps {
+  title: string
+  count?: string | number
+  moreButton?: boolean
+  children: React.ReactNode
+}
+
+const HeaderSection = ({
+  title,
+  count,
+  moreButton = false,
+  children,
+}: HeaderSectionProps) => {
+  return (
+    <section className={styles.HeaderSectionContainer}>
+      <div className={styles.HeaderSectionHeaderContainer}>
+        <h3 className={styles.HeaderSectionTitle}>
+          {title}
+          <span className={styles.HeaderSectionCount}>{count}</span>
+        </h3>
+        {moreButton && (
+          <button type="button" className={styles.HeaderSectionMoreButton}>
+            더보기
+          </button>
+        )}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export default HeaderSection

--- a/src/app/content/[id]/components/HeaderSection/HeaderSection.tsx
+++ b/src/app/content/[id]/components/HeaderSection/HeaderSection.tsx
@@ -4,6 +4,7 @@ interface HeaderSectionProps {
   title: string
   count?: string | number
   moreButton?: boolean
+  gap?: 'sm' | 'lg'
   children: React.ReactNode
 }
 
@@ -11,10 +12,11 @@ const HeaderSection = ({
   title,
   count,
   moreButton = false,
+  gap = 'sm',
   children,
 }: HeaderSectionProps) => {
   return (
-    <section className={styles.HeaderSectionContainer}>
+    <section className={styles.HeaderSectionContainer({ gap })}>
       <div className={styles.HeaderSectionHeaderContainer}>
         <h3 className={styles.HeaderSectionTitle}>
           {title}

--- a/src/app/content/[id]/layout.css.ts
+++ b/src/app/content/[id]/layout.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css'
+
+export const layoutWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '10px 15px',
+  gap: 49,
+})

--- a/src/app/content/[id]/layout.tsx
+++ b/src/app/content/[id]/layout.tsx
@@ -1,0 +1,7 @@
+import * as styles from './layout.css'
+
+const RootLayout = ({ children }: { children: React.ReactNode }) => {
+  return <div className={styles.layoutWrapper}>{children}</div>
+}
+
+export default RootLayout

--- a/src/app/styles.css.ts
+++ b/src/app/styles.css.ts
@@ -207,4 +207,7 @@ export const font = {
 
 globalStyle(':root', {
   fontFamily: fontFamily.font.body,
+  width: 375,
+  height: 667,
+  margin: '0 auto',
 })


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #39 

## 🎟️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 리팩토링

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 고정 레이아웃(375x667) 설정
2. 상세페이지 (/content/:id) 루트 레이아웃
3. 타이틀을 포함한 헤더를 갖고 있는 섹션 컴포넌트 생성

## 📢 To Reviewers

- 

## 📸 스크린샷

<img width="379" alt="스크린샷 2025-05-15 오후 10 16 10" src="https://github.com/user-attachments/assets/2dea9907-6894-4e0c-ab22-196183259603" />

## 🔗 참고 자료

<img width="379" alt="스크린샷 2025-05-15 오후 10 30 01" src="https://github.com/user-attachments/assets/1b34cb32-57d9-4d73-a1bc-e688fd60c554" />
<img width="379" alt="스크린샷 2025-05-15 오후 10 30 12" src="https://github.com/user-attachments/assets/0174bfa2-d148-453f-b6de-3cf9ec1ef29e" />
<img width="379" alt="스크린샷 2025-05-15 오후 10 30 25" src="https://github.com/user-attachments/assets/caf2542f-c96b-4b52-9696-c9bcadd5b9cc" />
